### PR TITLE
rename MPEG_buffer_circular.source as MPEG_buffer_circular.media

### DIFF
--- a/TV/scene.gltf
+++ b/TV/scene.gltf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:463f7f1afa25476f85f40e889826f0b89c5f381a258efafcb348578b3030640a
-size 22002
+oid sha256:e7c6c5f9c8f03452d57c591ca518e813079dbfb70b105024d496d6ed9651585a
+size 22000

--- a/video/scene.gltf
+++ b/video/scene.gltf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9943604c372b9906ee27fe4697ac7d0aa08f7a58dd9af6afa2061fbfed197511
-size 61609
+oid sha256:d63489b7aa0adc88f1e2022d4a976b6dfb0b2e705c1a930b33863b5b26236d37
+size 61607


### PR DESCRIPTION
fix 5G-MAG/rt-xr-content#1 
fix 5G-MAG/rt-xr-unity-player#2

the media producing the buffer should be referenced by the MPEG_buffer_circular.media property, not MPEG_buffer_circular.source which was used in draft specification.

The player has been updated to account for this change: https://github.com/5G-MAG/rt-xr-unity-player/pull/7
